### PR TITLE
dump() always fails, and returns a file descriptor as the error

### DIFF
--- a/lib/tiny.js
+++ b/lib/tiny.js
@@ -936,9 +936,7 @@ Tiny.prototype.dump = function(pretty, func) {
     if (func) func(err);
   });
 
-  stream.on('open', function(err) {
-    if (err) return func && func(err);
-
+  stream.on('open', function(fd) {
     stream.write('{\n');
 
     serial(keys, function(loop, docKey) {


### PR DESCRIPTION
The 'open' event is called with a file descriptor as the argument, not an error.
