### PR TITLE
dump() generates invalid JSON

### DIFF
--- a/lib/tiny.js
+++ b/lib/tiny.js
@@ -927,7 +927,9 @@ Tiny.prototype.dump = function(pretty, func) {
   var self = this
     , cache = self._cache
     , keys = Object.keys(cache)
-    , pretty = pretty ? 2 : 0;
+    , klength = keys.length
+    , pretty = pretty ? 2 : 0
+    , i = 0;
 
   var stream = fs.createWriteStream(self.name + '.json');
 
@@ -942,14 +944,17 @@ Tiny.prototype.dump = function(pretty, func) {
     stream.write('{\n');
 
     serial(keys, function(loop, docKey) {
+      i++;
       self.get(docKey, function(err, obj) {
         if (err) return func && func(err);
 
         var data = '"'
           + docKey
           + '": '
-          + JSON.stringify(obj, null, pretty)
-          + ',\n';
+          + JSON.stringify(obj, null, pretty);
+
+        if (i !== klength)
+          data += ',\n';
 
         if (stream.write(data) === false) {
           stream.once('drain', loop);


### PR DESCRIPTION
The last object had a comma at the end, which is invalid in JSON. This commit checks if we are working on the last item in the dump, and if we are, we don't print the comma at then end - and line break, which removes the blank line above the final `}`.
